### PR TITLE
Add a function that submits a kill task.

### DIFF
--- a/src/main/resources/kill-task.xsd
+++ b/src/main/resources/kill-task.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2017 mbr targeting GmbH
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<xs:schema xmlns="http://m6r.eu/druid/client/kill-task"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://m6r.eu/druid/client/kill-task">
+  <xs:complexType name="killTask">
+    <xs:sequence>
+      <xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dataSource" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="interval" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/src/main/scala/eu/m6r/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/eu/m6r/druid/client/DruidHttpClient.scala
@@ -342,7 +342,7 @@ object DruidHttpClient extends LazyLogging {
 
     cmd(Command.CopyDruidToDruid.cmd)
         .action((_, c) => c.copy(Some(Command.CopyDruidToDruid)))
-        .text("Copy a segment from on source to another")
+        .text("Copy a segment from one source to another")
         .children(
           opt[Seq[String]]('d', "dimensions").valueName("<dimension>,<dimension>...")
               .action((x, c) => c.copy(dimensions = x))
@@ -431,7 +431,7 @@ object DruidHttpClient extends LazyLogging {
         .children(
           opt[String]('s', "source").required().valueName("<source>")
               .action((x, c) => c.copy(source = x))
-              .text("Druid source to copy from"),
+              .text("Druid source to delete segments from"),
           opt[String]("segment-start").required().valueName("<segmentStart>")
               .action((x, c) => c.copy(segmentStart = DATE_FORMATTER.parseDateTime(x)))
               .text("Segment start time. Format: yyyy-MM-ddThh:mm:ssZ"),

--- a/src/main/scala/eu/m6r/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/eu/m6r/druid/client/DruidHttpClient.scala
@@ -56,6 +56,7 @@ import eu.m6r.druid.client.granularities.SegmentGranularity
 import eu.m6r.druid.client.models.DruidHost
 import eu.m6r.druid.client.models.IndexTask
 import eu.m6r.druid.client.models.IndexTaskBuilder
+import eu.m6r.druid.client.models.KillTaskBuilder
 import eu.m6r.druid.client.models.RunningTask
 import eu.m6r.druid.client.models.TaskStatus
 
@@ -211,6 +212,43 @@ case class DruidHttpClient(zookeeperHosts: String) extends LazyLogging {
         .map(_.map(deleteSegment(_).map(_.segment)))
         .flatMap(x => Future.sequence(x))
 
+  /** Kills all segments inside a given interval
+    *
+    * @param dataSource Name of the Druid data source.
+    * @param interval The interval. All segements inside the intervals time range will be killed.
+    * @return Future containing id of the kill task.
+    */
+  def killSegmentsInInterval(dataSource: String, interval: Interval): Future[String] = {
+    getCoordinator.map(coordinator => {
+      val killSegmentsPath =
+        s"http://${coordinator.address}:${coordinator.port}/druid/indexer/v1/task/"
+
+      val killTask = new KillTaskBuilder()
+        .withDataSource(dataSource)
+        .withInterval(interval)
+        .build()
+
+      val taskJson = objectMapper.writeValueAsString(killTask)
+
+      val response = Http(killSegmentsPath)
+        .postData(taskJson)
+        .header("content-type", "application/json")
+        .method("POST")
+        .asString
+
+      if (response.isError) {
+        throw new IOException(s"Request failed:${response.body}")
+      }
+
+      response match {
+        case HttpResponse(body: String, HttpStatus.SC_OK, _) =>
+          val taskId = objectMapper.readValue[ObjectNode](body).get("task").textValue()
+          taskId
+        case _ => throw DruidHttpClient.httpException(response)
+      }
+    })
+  }
+
   /** Closes a running indexing task
     *
     * @param taskId Id of the task that shall be closed.
@@ -275,6 +313,8 @@ object DruidHttpClient extends LazyLogging {
     case object TaskStatus extends Command("task-status")
 
     case object DeleteSegments extends Command("delete-segments")
+
+    case object KillSegments extends Command("kill-segments")
 
   }
 
@@ -399,6 +439,20 @@ object DruidHttpClient extends LazyLogging {
               .action((x, c) => c.copy(segmentEnd = Some(DATE_FORMATTER.parseDateTime(x))))
               .text("Segment end time. Format: yyyy-MM-ddThh:mm:ssZ")
         )
+    cmd(Command.KillSegments.cmd)
+        .action((_, c) => c.copy(Some(Command.KillSegments)))
+        .text("Kills segment(s) in a specified data source")
+        .children(
+          opt[String]('s', "source").required().valueName("<source>")
+              .action((x, c) => c.copy(source = x))
+              .text("Druid source to kill segments in"),
+          opt[String]("segment-start").required().valueName("<segmentStart>")
+              .action((x, c) => c.copy(segmentStart = DATE_FORMATTER.parseDateTime(x)))
+              .text("Segment start time. Format: yyyy-MM-ddThh:mm:ssZ"),
+          opt[String]("segment-end").required().valueName("<segmentEnd>")
+              .action((x, c) => c.copy(segmentEnd = Some(DATE_FORMATTER.parseDateTime(x))))
+              .text("Segment end time. Format: yyyy-MM-ddThh:mm:ssZ")
+        )
 
     cmd(Command.TaskStatus.cmd)
         .action((_, c) => c.copy(Some(Command.TaskStatus)))
@@ -476,6 +530,9 @@ object DruidHttpClient extends LazyLogging {
           case Command.DeleteSegments =>
             val interval = new Interval(conf.segmentStart, conf.segmentEnd.get)
             client.deleteSegmentsInInterval(conf.source, interval)
+          case Command.KillSegments =>
+            val interval = new Interval(conf.segmentStart, conf.segmentEnd.get)
+            client.killSegmentsInInterval(conf.source, interval)
         }
 
         Await.result(future, 2 hours)

--- a/src/main/scala/eu/m6r/druid/client/models/KillTaskBuilder.scala
+++ b/src/main/scala/eu/m6r/druid/client/models/KillTaskBuilder.scala
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 mbr targeting GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package eu.m6r.druid.client.models
+
+import org.joda.time.Interval
+
+import eu.m6r.druid.client.models.KillTaskBuilder.BuilderValidationException
+
+/** Builder class for [[KillTask]] instances.
+  *
+  * Creates an [[KillTask]] object as specified by the
+  * [[http://druid.io/docs/latest/ingestion/tasks.html druid API]].
+  */
+final class KillTaskBuilder {
+
+  protected var dataSource: Option[String] = None
+  protected var interval: Option[String] = None
+
+  /** Updates builder by setting dataSource.
+    *
+    * @param dataSource Name of the data source.
+    * @return Updated builder.
+    */
+  def withDataSource(dataSource: String): KillTaskBuilder = {
+    this.dataSource = Some(dataSource)
+    this
+  }
+
+  /** Updates builder by setting the interval.
+    *
+    * @param interval The interval to kill segments in.
+    * @return Updated builder.
+    */
+  def withInterval(interval: Interval): KillTaskBuilder = {
+    this.interval = Some(interval.toString)
+    this
+  }
+
+  /** Builds the [[eu.m6r.druid.client.models.KillTask]] from the current builder state.
+    *
+    * @return The built kill task.
+    */
+  def build(): KillTask = {
+    validate()
+
+    val killTask = new KillTask
+    killTask.setId(s"kill_${dataSource.get}_${intervalFormatted}")
+    killTask.setType("kill")
+    killTask.setInterval(interval.get)
+    killTask.setDataSource(dataSource.get)
+
+    killTask
+  }
+
+  private def intervalFormatted: String = {
+    this.interval.get.toString.replaceAll("/", "_")
+  }
+
+  private def validate(): Unit = {
+    if (dataSource.isEmpty) throw new BuilderValidationException("dataSource")
+    if (interval.isEmpty) throw new BuilderValidationException("interval")
+  }
+}
+
+object KillTaskBuilder {
+
+  private class BuilderValidationException(field: String) extends Exception {
+
+    override def getMessage: String = {
+      s"Required field '${field}' is not set."
+    }
+  }
+}


### PR DESCRIPTION
In the MBR-2802 issue there was a task to kill old segments from HDFS. Those segments have been deleted manually but there was also an idea to incorporate this within `druid-client` to have an ability to automate the deletion.

Since then it was discovered that druid's deletion rules can be configured so that they do remove the segments from the deep storage (which by default doesn't happen). And this idea of implementing it ourselves became obsolete. 

However, there is some work that's already been done and this is why I decided to make this pull request.